### PR TITLE
Improve API error handling and HTTP statuses

### DIFF
--- a/src/main/java/vendredi/soir/posu/endpoint/rest/controller/WalletController.java
+++ b/src/main/java/vendredi/soir/posu/endpoint/rest/controller/WalletController.java
@@ -20,15 +20,11 @@ public class WalletController {
 
   @PostMapping
   public ResponseEntity<List<Wallet>> createWallet(@RequestBody List<WalletMinimalInfo> wallets) {
-    try {
-      List<Wallet> createdWallets =
-          walletService.createWallets(wallets).stream()
-              .map(walletMapper::toRest)
-              .collect(Collectors.toList());
-      return ResponseEntity.status(HttpStatus.CREATED).body(createdWallets);
-    } catch (IllegalArgumentException e) {
-      return ResponseEntity.status(HttpStatus.CONFLICT).build();
-    }
+    List<Wallet> createdWallets =
+        walletService.createWallets(wallets).stream()
+            .map(walletMapper::toRest)
+            .collect(Collectors.toList());
+    return ResponseEntity.status(HttpStatus.CREATED).body(createdWallets);
   }
 
   @GetMapping

--- a/src/main/java/vendredi/soir/posu/endpoint/rest/mapper/TransactionMapper.java
+++ b/src/main/java/vendredi/soir/posu/endpoint/rest/mapper/TransactionMapper.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import vendredi.soir.posu.endpoint.rest.model.TransactionMinimalInfo;
 import vendredi.soir.posu.model.Transaction;
 import vendredi.soir.posu.model.User;
+import vendredi.soir.posu.model.exception.NotFoundException;
 import vendredi.soir.posu.repository.LabelRepository;
 
 @Component
@@ -27,7 +28,7 @@ public class TransactionMapper {
                     labelRepository
                         .findByReferenceAndUser(label, user)
                         .orElseThrow(
-                            () -> new IllegalArgumentException("Label not found: " + label)))
+                            () -> new NotFoundException("Label not found: " + label)))
             .collect(Collectors.toList()),
         rest.getDescription(),
         null,

--- a/src/main/java/vendredi/soir/posu/endpoint/rest/model/Exception.java
+++ b/src/main/java/vendredi/soir/posu/endpoint/rest/model/Exception.java
@@ -1,0 +1,15 @@
+package vendredi.soir.posu.endpoint.rest.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Exception {
+  private String type;
+  private String message;
+}

--- a/src/main/java/vendredi/soir/posu/handler/GlobalExceptionHandler.java
+++ b/src/main/java/vendredi/soir/posu/handler/GlobalExceptionHandler.java
@@ -1,15 +1,59 @@
 package vendredi.soir.posu.handler;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import vendredi.soir.posu.endpoint.rest.model.Exception;
+import vendredi.soir.posu.model.exception.ApiException;
+import vendredi.soir.posu.model.exception.BadRequestException;
+import vendredi.soir.posu.model.exception.ConflictException;
+import vendredi.soir.posu.model.exception.ForbiddenException;
+import vendredi.soir.posu.model.exception.NotFoundException;
 
 @ControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<Exception> handleBadRequestException(BadRequestException ex) {
+    return new ResponseEntity<>(toRest(ex, "BadRequestException"), HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(NotFoundException.class)
+  public ResponseEntity<Exception> handleNotFoundException(NotFoundException ex) {
+    return new ResponseEntity<>(toRest(ex, "NotFoundException"), HttpStatus.NOT_FOUND);
+  }
+
+  @ExceptionHandler(ConflictException.class)
+  public ResponseEntity<Exception> handleConflictException(ConflictException ex) {
+    return new ResponseEntity<>(toRest(ex, "ConflictException"), HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(ForbiddenException.class)
+  public ResponseEntity<Exception> handleForbiddenException(ForbiddenException ex) {
+    return new ResponseEntity<>(toRest(ex, "ForbiddenException"), HttpStatus.FORBIDDEN);
+  }
+
   @ExceptionHandler(IllegalArgumentException.class)
-  public ResponseEntity<String> handleIllegalArgumentException(IllegalArgumentException ex) {
-    return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+  public ResponseEntity<Exception> handleIllegalArgumentException(IllegalArgumentException ex) {
+    return new ResponseEntity<>(toRest(ex, "BadRequestException"), HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(java.lang.Exception.class)
+  public ResponseEntity<Exception> handleDefaultException(java.lang.Exception ex) {
+    log.error("Internal Server Error", ex);
+    Exception restException =
+        Exception.builder().type("InternalServerError").message("An internal error occurred").build();
+    return new ResponseEntity<>(restException, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  private Exception toRest(ApiException ex, String type) {
+    return Exception.builder().type(type).message(ex.getMessage()).build();
+  }
+
+  private Exception toRest(IllegalArgumentException ex, String type) {
+    return Exception.builder().type(type).message(ex.getMessage()).build();
   }
 }

--- a/src/main/java/vendredi/soir/posu/model/exception/ApiException.java
+++ b/src/main/java/vendredi/soir/posu/model/exception/ApiException.java
@@ -1,0 +1,7 @@
+package vendredi.soir.posu.model.exception;
+
+public abstract class ApiException extends RuntimeException {
+  public ApiException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/vendredi/soir/posu/model/exception/BadRequestException.java
+++ b/src/main/java/vendredi/soir/posu/model/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package vendredi.soir.posu.model.exception;
+
+public class BadRequestException extends ApiException {
+  public BadRequestException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/vendredi/soir/posu/model/exception/ConflictException.java
+++ b/src/main/java/vendredi/soir/posu/model/exception/ConflictException.java
@@ -1,0 +1,7 @@
+package vendredi.soir.posu.model.exception;
+
+public class ConflictException extends ApiException {
+  public ConflictException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/vendredi/soir/posu/model/exception/ForbiddenException.java
+++ b/src/main/java/vendredi/soir/posu/model/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package vendredi.soir.posu.model.exception;
+
+public class ForbiddenException extends ApiException {
+  public ForbiddenException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/vendredi/soir/posu/model/exception/NotFoundException.java
+++ b/src/main/java/vendredi/soir/posu/model/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package vendredi.soir.posu.model.exception;
+
+public class NotFoundException extends ApiException {
+  public NotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/vendredi/soir/posu/service/LabelService.java
+++ b/src/main/java/vendredi/soir/posu/service/LabelService.java
@@ -9,6 +9,7 @@ import vendredi.soir.posu.endpoint.rest.mapper.LabelMapper;
 import vendredi.soir.posu.endpoint.rest.model.LabelMinimalInfo;
 import vendredi.soir.posu.model.Label;
 import vendredi.soir.posu.model.User;
+import vendredi.soir.posu.model.exception.ConflictException;
 import vendredi.soir.posu.repository.LabelRepository;
 
 @Service
@@ -25,7 +26,7 @@ public class LabelService {
             .peek(
                 label -> {
                   if (labelRepository.existsByReferenceAndUser(label.getReference(), currentUser)) {
-                    throw new IllegalArgumentException(
+                    throw new ConflictException(
                         "Label with reference " + label.getReference() + " already exists");
                   }
                   label.setUser(currentUser);

--- a/src/main/java/vendredi/soir/posu/service/TransactionService.java
+++ b/src/main/java/vendredi/soir/posu/service/TransactionService.java
@@ -10,6 +10,7 @@ import vendredi.soir.posu.endpoint.rest.model.TransactionMinimalInfo;
 import vendredi.soir.posu.model.Transaction;
 import vendredi.soir.posu.model.User;
 import vendredi.soir.posu.model.Wallet;
+import vendredi.soir.posu.model.exception.NotFoundException;
 import vendredi.soir.posu.repository.TransactionRepository;
 import vendredi.soir.posu.repository.WalletRepository;
 
@@ -32,7 +33,7 @@ public class TransactionService {
                               transaction.getWalletReference(), currentUser)
                           .orElseThrow(
                               () ->
-                                  new IllegalArgumentException(
+                                  new NotFoundException(
                                       "Wallet not found or does not belong to user: "
                                           + transaction.getWalletReference()));
                   return transactionMapper.toDomain(transaction, currentUser);

--- a/src/main/java/vendredi/soir/posu/service/UserService.java
+++ b/src/main/java/vendredi/soir/posu/service/UserService.java
@@ -11,6 +11,8 @@ import vendredi.soir.posu.endpoint.rest.model.RegisterRequest;
 import vendredi.soir.posu.model.User;
 import vendredi.soir.posu.model.Wallet;
 import vendredi.soir.posu.model.WalletType;
+import vendredi.soir.posu.model.exception.ConflictException;
+import vendredi.soir.posu.model.exception.ForbiddenException;
 import vendredi.soir.posu.repository.UserRepository;
 import vendredi.soir.posu.repository.WalletRepository;
 
@@ -24,10 +26,10 @@ public class UserService {
   @Transactional
   public User register(RegisterRequest request) {
     if (userRepository.existsByUsername(request.getUsername())) {
-      throw new IllegalArgumentException("Username already exists");
+      throw new ConflictException("Username already exists");
     }
     if (userRepository.existsByEmail(request.getEmail())) {
-      throw new IllegalArgumentException("Email already exists");
+      throw new ConflictException("Email already exists");
     }
 
     User user =
@@ -61,6 +63,6 @@ public class UserService {
     return userRepository
         .findByUsername(request.getUsername())
         .filter(user -> passwordEncoder.matches(request.getPassword(), user.getPassword()))
-        .orElseThrow(() -> new IllegalArgumentException("Invalid username or password"));
+        .orElseThrow(() -> new ForbiddenException("Invalid username or password"));
   }
 }

--- a/src/main/java/vendredi/soir/posu/service/WalletService.java
+++ b/src/main/java/vendredi/soir/posu/service/WalletService.java
@@ -9,6 +9,7 @@ import vendredi.soir.posu.endpoint.rest.mapper.WalletMapper;
 import vendredi.soir.posu.endpoint.rest.model.WalletMinimalInfo;
 import vendredi.soir.posu.model.User;
 import vendredi.soir.posu.model.Wallet;
+import vendredi.soir.posu.model.exception.ConflictException;
 import vendredi.soir.posu.repository.WalletRepository;
 
 @Service
@@ -26,7 +27,7 @@ public class WalletService {
                 wallet -> {
                   if (walletRepository.existsByReferenceAndUsersContaining(
                       wallet.getReference(), currentUser)) {
-                    throw new IllegalArgumentException(
+                    throw new ConflictException(
                         "Wallet with reference " + wallet.getReference() + " already exists");
                   }
                   wallet.setUsers(List.of(currentUser));

--- a/src/test/java/vendredi/soir/posu/service/LabelServiceTest.java
+++ b/src/test/java/vendredi/soir/posu/service/LabelServiceTest.java
@@ -18,6 +18,7 @@ import vendredi.soir.posu.endpoint.rest.mapper.LabelMapper;
 import vendredi.soir.posu.endpoint.rest.model.LabelMinimalInfo;
 import vendredi.soir.posu.model.Label;
 import vendredi.soir.posu.model.User;
+import vendredi.soir.posu.model.exception.ConflictException;
 import vendredi.soir.posu.repository.LabelRepository;
 
 class LabelServiceTest {
@@ -68,7 +69,7 @@ class LabelServiceTest {
     when(labelMapper.toDomain(info)).thenReturn(label);
     when(labelRepository.existsByReferenceAndUser("REF1", user)).thenReturn(true);
 
-    assertThrows(IllegalArgumentException.class, () -> labelService.createLabels(List.of(info)));
+    assertThrows(ConflictException.class, () -> labelService.createLabels(List.of(info)));
   }
 
   @Test

--- a/src/test/java/vendredi/soir/posu/service/TransactionServiceTest.java
+++ b/src/test/java/vendredi/soir/posu/service/TransactionServiceTest.java
@@ -20,6 +20,7 @@ import vendredi.soir.posu.endpoint.rest.model.TransactionMinimalInfo;
 import vendredi.soir.posu.model.Transaction;
 import vendredi.soir.posu.model.User;
 import vendredi.soir.posu.model.Wallet;
+import vendredi.soir.posu.model.exception.NotFoundException;
 import vendredi.soir.posu.repository.TransactionRepository;
 import vendredi.soir.posu.repository.WalletRepository;
 
@@ -70,6 +71,6 @@ class TransactionServiceTest {
 
     when(walletRepository.findByReferenceAndUsersContaining("W1", user)).thenReturn(Optional.empty());
 
-    assertThrows(IllegalArgumentException.class, () -> transactionService.recordTransactions(List.of(info)));
+    assertThrows(NotFoundException.class, () -> transactionService.recordTransactions(List.of(info)));
   }
 }

--- a/src/test/java/vendredi/soir/posu/service/WalletServiceTest.java
+++ b/src/test/java/vendredi/soir/posu/service/WalletServiceTest.java
@@ -18,6 +18,7 @@ import vendredi.soir.posu.endpoint.rest.mapper.WalletMapper;
 import vendredi.soir.posu.endpoint.rest.model.WalletMinimalInfo;
 import vendredi.soir.posu.model.User;
 import vendredi.soir.posu.model.Wallet;
+import vendredi.soir.posu.model.exception.ConflictException;
 import vendredi.soir.posu.repository.WalletRepository;
 
 class WalletServiceTest {
@@ -68,6 +69,6 @@ class WalletServiceTest {
     when(walletMapper.toDomain(info)).thenReturn(wallet);
     when(walletRepository.existsByReferenceAndUsersContaining("REF1", user)).thenReturn(true);
 
-    assertThrows(IllegalArgumentException.class, () -> walletService.createWallets(List.of(info)));
+    assertThrows(ConflictException.class, () -> walletService.createWallets(List.of(info)));
   }
 }


### PR DESCRIPTION
This change improves the API's error handling by introducing a centralized mechanism using @ControllerAdvice. It ensures that the client receives proper HTTP status codes (4xx/5xx) and a structured JSON response containing the error type and message, instead of plain text or generic internal server errors. Service layers now throw specific domain exceptions that map directly to these HTTP statuses.

---
*PR created automatically by Jules for task [3574502177464823009](https://jules.google.com/task/3574502177464823009) started by @daniel-langio*