### PR TITLE
fix: prevent error when recreating enum types with dependencies

### DIFF
--- a/src/main/resources/db/migration/V1_1__Create_wallet_type.sql
+++ b/src/main/resources/db/migration/V1_1__Create_wallet_type.sql
@@ -1,8 +1,11 @@
-DROP TYPE IF EXISTS wallet_type;
-
-CREATE TYPE wallet_type AS ENUM (
-    'CASH',
-    'BANK_ACCOUNT',
-    'MOBILE_MONEY',
-    'CRYPTO'
-);
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'wallet_type') THEN
+        CREATE TYPE wallet_type AS ENUM (
+            'CASH',
+            'BANK_ACCOUNT',
+            'MOBILE_MONEY',
+            'CRYPTO'
+        );
+    END IF;
+END$$;

--- a/src/main/resources/db/migration/V1_3__Create_transaction_type.sql
+++ b/src/main/resources/db/migration/V1_3__Create_transaction_type.sql
@@ -1,2 +1,6 @@
-DROP TYPE IF EXISTS transaction_type;
-CREATE TYPE transaction_type AS ENUM ('IN', 'OUT');
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'transaction_type') THEN
+        CREATE TYPE transaction_type AS ENUM ('IN', 'OUT');
+    END IF;
+END$$;


### PR DESCRIPTION
This PR addresses a Flyway migration error where `DROP TYPE IF EXISTS` failed because the type was already referenced by tables (e.g., the `wallet` table depending on `wallet_type`).

Changes:
- Replaced destructive `DROP TYPE` with idempotent `DO` blocks in `V1_1__Create_wallet_type.sql` and `V1_3__Create_transaction_type.sql`.
- These blocks check for the existence of the type in `pg_type` before attempting creation.

Verified by simulating the dependency conflict in a local PostgreSQL instance and confirming that the new migration logic handles it correctly.

---
*PR created automatically by Jules for task [3640609118721956927](https://jules.google.com/task/3640609118721956927) started by @daniel-langio*