### PR TITLE
Make Flyway migrations idempotent

### DIFF
--- a/src/main/resources/db/migration/V1_2__Create_wallet_table.sql
+++ b/src/main/resources/db/migration/V1_2__Create_wallet_table.sql
@@ -6,4 +6,4 @@ CREATE TABLE IF NOT EXISTS wallet(
     reference VARCHAR
 );
 
-INSERT INTO wallet(name, reference) VALUES ('LIQUIDE', 'DEFAULT_LIQUIDE');
+INSERT INTO wallet(name, reference) VALUES ('LIQUIDE', 'DEFAULT_LIQUIDE') ON CONFLICT (name) DO NOTHING;

--- a/src/main/resources/db/migration/V2_1__Drop_category_schema.sql
+++ b/src/main/resources/db/migration/V2_1__Drop_category_schema.sql
@@ -1,5 +1,5 @@
-ALTER TABLE "transaction" DROP COLUMN "category_id";
-ALTER TABLE "transaction" DROP COLUMN "sub_category";
+ALTER TABLE "transaction" DROP COLUMN IF EXISTS "category_id";
+ALTER TABLE "transaction" DROP COLUMN IF EXISTS "sub_category";
 
 DROP TABLE IF EXISTS "transaction_sub_category";
 DROP TABLE IF EXISTS "transaction_category";

--- a/src/main/resources/db/migration/V3_5__Make_references_unique_per_user.sql
+++ b/src/main/resources/db/migration/V3_5__Make_references_unique_per_user.sql
@@ -10,7 +10,7 @@ ALTER TABLE "wallet" DROP CONSTRAINT IF EXISTS wallet_name_key;
 ALTER TABLE "label" DROP CONSTRAINT IF EXISTS label_reference_key;
 
 -- Add user_id to label
-ALTER TABLE "label" ADD COLUMN user_id VARCHAR(255) REFERENCES "user"(id);
+ALTER TABLE "label" ADD COLUMN IF NOT EXISTS user_id VARCHAR(255) REFERENCES "user"(id);
 
 -- Assign existing labels to the first user found, if any
 DO $$
@@ -24,4 +24,11 @@ BEGIN
 END $$;
 
 -- Add unique constraint on (user_id, reference) for label
-ALTER TABLE "label" ADD CONSTRAINT label_user_id_reference_uq UNIQUE (user_id, reference);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'label_user_id_reference_uq'
+    ) THEN
+        ALTER TABLE "label" ADD CONSTRAINT label_user_id_reference_uq UNIQUE (user_id, reference);
+    END IF;
+END$$;

--- a/src/main/resources/db/migration/V3_6__Add_creation_datetime_to_user_table.sql
+++ b/src/main/resources/db/migration/V3_6__Add_creation_datetime_to_user_table.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "user" ADD COLUMN creation_datetime timestamp with time zone NOT NULL DEFAULT now();
+ALTER TABLE "user" ADD COLUMN IF NOT EXISTS creation_datetime timestamp with time zone NOT NULL DEFAULT now();


### PR DESCRIPTION
This change updates all existing Flyway migration scripts to be idempotent. This ensures that the migrations can be run multiple times without failure, which is particularly useful for environment bootstrapping and recovery.

Key changes:
- V1_2: Added ON CONFLICT (name) DO NOTHING to the default wallet insertion.
- V2_1: Added IF EXISTS to DROP COLUMN statements.
- V3_5: Added IF NOT EXISTS to user_id column addition and wrapped label_user_id_reference_uq constraint addition in a DO block.
- V3_6: Added IF NOT EXISTS to creation_datetime column addition.
- Verified that other migrations (like V3_2) are already idempotent or use existing idempotency patterns.

---
*PR created automatically by Jules for task [15581834210514725980](https://jules.google.com/task/15581834210514725980) started by @daniel-langio*